### PR TITLE
0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@
 - Dark theme
 - Vertically centered overlay
 
+## 0.4.7 (2018-03-30)
+
+- Changed previous tab command behavior: When the search input is active, going to the previous tab selects the last tab instead
+- Improved key-handling for common system shortcuts:
+  + <kbd>Shift</kbd>-<kbd>Tab</kbd> now goes to the previous item in the tab list
+  + <kbd>Home</kbd> and <kbd>End</kbd> jump to the beginning or the ending of the tab list
+  + <kbd>PgUp</kbd> and <kbd>PgDown</kbd> go to the previous or next tab in the tab list
+
 ## 0.4.6 (2018-02-27)
 
 - Added ability to bind a second shortcut

--- a/src/core/pages/popup/event-callbacks.js
+++ b/src/core/pages/popup/event-callbacks.js
@@ -109,8 +109,7 @@ export function keydownHandler(store) {
     if (isModifierSingle(event)) {
       event.preventDefault();
     }
-    // Handle preventing default
-    // Delete, Backspace, Tab, ArrowUp, Arrowdown, Enter
+    // Handle preventing default key actions
     switch (event.key) {
       case 'Tab':
       //   // Change it so tab no longer focuses the entire popup window
@@ -122,6 +121,12 @@ export function keydownHandler(store) {
       case 'ArrowDown':
       case 'Enter':
         event.preventDefault();
+        break;
+      case 'End':
+        tabList.lastChild.focus();
+        break;
+      case 'Home':
+        tabList.firstChild.focus();
         break;
       default: break;
     }

--- a/src/core/pages/popup/event-callbacks.js
+++ b/src/core/pages/popup/event-callbacks.js
@@ -1,5 +1,5 @@
 /* Main DOM event-handlers */
-import keyboard, { TAB_NEXT } from 'core/keyboard';
+import keyboard, { TAB_NEXT, TAB_PREV } from 'core/keyboard';
 import {
   injectTabsInList,
   addHeadTabListNodeSelectedStyle,
@@ -131,7 +131,10 @@ export function keydownHandler(store) {
       return navigateResults(kbdControlMap.get(key), store.getState);
     }
     if (event.key === 'Tab') {
-      return navigateResults(TAB_NEXT, store.getState);
+      return navigateResults(
+        event.shiftKey ? TAB_PREV : TAB_NEXT,
+        store.getState,
+      );
     }
     const shouldJustFocusSearchBar = (event.key === 'Backspace' && !isModifierSingle(event))
       || (/^([A-Za-z]|\d)$/.test(event.key) && !isModifierSingle(event));

--- a/src/core/pages/popup/utils/keyboard.js
+++ b/src/core/pages/popup/utils/keyboard.js
@@ -63,8 +63,10 @@ export function navigateResults(cmdKey, getState) {
       const prevSibling = selectedTab.previousElementSibling;
       if (prevSibling) {
         prevSibling.focus();
-      } else {
+      } else if (document.activeElement !== searchInput) {
         searchInput.focus();
+      } else { // We're at the top but searchInput is focused
+        tabList.lastChild.focus();
       }
       break;
     }

--- a/src/manifest/base.json
+++ b/src/manifest/base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "TabSearch",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Easy tab search & switching",
   "permissions": [
     "tabs",


### PR DESCRIPTION
Closes #55, #56
- Changed previous tab command behavior: When the search input is active, going to the previous tab selects the last tab instead
- Improved key-handling for common system shortcuts:
  + <kbd>Shift</kbd>-<kbd>Tab</kbd> now goes to the previous item in the tab list
  + <kbd>Home</kbd> and <kbd>End</kbd> jump to the beginning or the ending of the tab list
  + <kbd>PgUp</kbd> and <kbd>PgDown</kbd> go to the previous or next tab in the tab list
