### PR TITLE
Only perform query when there's input

### DIFF
--- a/src/core/pages/popup/event-callbacks.js
+++ b/src/core/pages/popup/event-callbacks.js
@@ -36,23 +36,25 @@ export function configureSearch(store) {
       deleteButton.classList.add('hidden');
     } else {
       deleteButton.classList.remove('hidden');
+      //only perform query when there's input
+      
+      // isSearchEmpty isn't based on this var so we can show delete button with
+      // just spaces
+      const query = event.currentTarget.value.trim().toLowerCase();
+      return Promise.resolve(tabQueryPromise())
+        .then(filterResults(query, fuzzy, general, currentWindowId))
+        .then(injectTabsInList(getState))
+        .then((results) => {
+          // Apply the selected style to the head of the tabList to suggest
+          // pressing <Enter> from the search input activates this tab
+          if (results.length > 0 && !isSearchEmpty) {
+            addHeadTabListNodeSelectedStyle();
+            // Scroll to the top
+            tabList.firstElementChild.scrollIntoView(true);
+          }
+          return results;
+        });
     }
-    // isSearchEmpty isn't based on this var so we can show delete button with
-    // just spaces
-    const query = event.currentTarget.value.trim().toLowerCase();
-    return Promise.resolve(tabQueryPromise())
-      .then(filterResults(query, fuzzy, general, currentWindowId))
-      .then(injectTabsInList(getState))
-      .then((results) => {
-        // Apply the selected style to the head of the tabList to suggest
-        // pressing <Enter> from the search input activates this tab
-        if (results.length > 0 && !isSearchEmpty) {
-          addHeadTabListNodeSelectedStyle();
-          // Scroll to the top
-          tabList.firstElementChild.scrollIntoView(true);
-        }
-        return results;
-      });
   };
 }
 


### PR DESCRIPTION
Don't run a search query on an empty string.

This removes an unnecessary search before the user types their query,
which is slow for my ~800 tabs over 2 windows (on x64 Firefox 66, Debian-flavour Linux).

Reduces the time-to-search when opening the popup window.

(I literally just moved the curly brace for the else statement on `isSearchEmpty`, indented the query block, and added a comment about this).